### PR TITLE
nft: N-11 Unused inherited contract

### DIFF
--- a/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
@@ -4,13 +4,11 @@ pragma solidity 0.8.15;
 import {
     CrossDomainEnabled
 } from "@eth-optimism/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol";
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { L2ERC721Bridge } from "../L2/L2ERC721Bridge.sol";
 import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 /**
  * @title L1ERC721Bridge
@@ -18,7 +16,7 @@ import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semv
  *         make it possible to transfer ERC721 tokens between Optimism and Ethereum. This contract
  *         acts as an escrow for ERC721 tokens deposted into L2.
  */
-contract L1ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
+contract L1ERC721Bridge is Semver, CrossDomainEnabled, Initializable {
     /**
      * @notice Emitted when an ERC721 bridge to the other network is initiated.
      *
@@ -89,9 +87,6 @@ contract L1ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     function initialize(address _messenger, address _otherBridge) public initializer {
         messenger = _messenger;
         otherBridge = _otherBridge;
-
-        // Initialize upgradable OZ contracts
-        __Ownable_init();
     }
 
     /**

--- a/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
@@ -4,14 +4,12 @@ pragma solidity 0.8.15;
 import {
     CrossDomainEnabled
 } from "@eth-optimism/contracts/contracts/libraries/bridge/CrossDomainEnabled.sol";
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { L1ERC721Bridge } from "../L1/L1ERC721Bridge.sol";
 import { IOptimismMintableERC721 } from "../universal/op-erc721/IOptimismMintableERC721.sol";
 import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 /**
  * @title L2ERC721Bridge
@@ -20,7 +18,7 @@ import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semv
  *         acts as a minter for new tokens when it hears about deposits into the L1 ERC721 bridge.
  *         This contract also acts as a burner for tokens being withdrawn.
  */
-contract L2ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
+contract L2ERC721Bridge is Semver, CrossDomainEnabled, Initializable {
     /**
      * @notice Emitted when an ERC721 bridge to the other network is initiated.
      *
@@ -103,9 +101,6 @@ contract L2ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     function initialize(address _messenger, address _otherBridge) public initializer {
         messenger = _messenger;
         otherBridge = _otherBridge;
-
-        // Initialize upgradable OZ contracts
-        __Ownable_init();
     }
 
     /**

--- a/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
+++ b/packages/contracts-periphery/contracts/universal/op-erc721/OptimismMintableERC721Factory.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import {
-    OwnableUpgradeable
-} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import { OptimismMintableERC721 } from "./OptimismMintableERC721.sol";
 import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semver.sol";
 
@@ -11,7 +9,7 @@ import { Semver } from "@eth-optimism/contracts-bedrock/contracts/universal/Semv
  * @title OptimismMintableERC721Factory
  * @notice Factory contract for creating OptimismMintableERC721 contracts.
  */
-contract OptimismMintableERC721Factory is Semver, OwnableUpgradeable {
+contract OptimismMintableERC721Factory is Semver, Initializable {
     /**
      * @notice Emitted whenever a new OptimismMintableERC721 contract is created.
      *
@@ -52,9 +50,6 @@ contract OptimismMintableERC721Factory is Semver, OwnableUpgradeable {
     function initialize(address _bridge, uint256 _remoteChainId) public initializer {
         bridge = _bridge;
         remoteChainId = _remoteChainId;
-
-        // Initialize upgradable OZ contracts
-        __Ownable_init();
     }
 
     /**


### PR DESCRIPTION
Removes unused `OwnableUpgradeable` import in NFT bridge contracts. Also removes this import in `OptimismMintableERC721Factory`, which is not mentioned in this finding, but the import is unused nonetheless.