### PR TITLE
nft: N-10 Undocumented implicit approval requirements

### DIFF
--- a/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L1/L1ERC721Bridge.sol
@@ -95,7 +95,9 @@ contract L1ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     }
 
     /**
-     * @notice Initiates a bridge of an NFT to the caller's account on L2.
+     * @notice Initiates a bridge of an NFT to the caller's account on L2. Note that the current
+     *         owner of the token on this chain must approve this contract to operate the NFT before
+     *         it can be bridged.
      *
      * @param _localToken  Address of the ERC721 on this domain.
      * @param _remoteToken Address of the ERC721 on the remote domain.
@@ -128,7 +130,9 @@ contract L1ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     }
 
     /**
-     * @notice Initiates a bridge of an NFT to some recipient's account on L2.
+     * @notice Initiates a bridge of an NFT to some recipient's account on L2. Note that the current
+     *         owner of the token on this chain must approve this contract to operate the NFT before
+     *         it can be bridged.
      *
      * @param _localToken  Address of the ERC721 on this domain.
      * @param _remoteToken Address of the ERC721 on the remote domain.

--- a/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
+++ b/packages/contracts-periphery/contracts/L2/L2ERC721Bridge.sol
@@ -109,7 +109,9 @@ contract L2ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     }
 
     /**
-     * @notice Initiates a bridge of an NFT to the caller's account on L1.
+     * @notice Initiates a bridge of an NFT to the caller's account on L1. Note that the current
+     *         owner of the token on this chain must approve this contract to operate the NFT before
+     *         it can be bridged.
      *
      * @param _localToken  Address of the ERC721 on this domain.
      * @param _remoteToken Address of the ERC721 on the remote domain.
@@ -142,7 +144,9 @@ contract L2ERC721Bridge is Semver, CrossDomainEnabled, OwnableUpgradeable {
     }
 
     /**
-     * @notice Initiates a bridge of an NFT to some recipient's account on L1.
+     * @notice Initiates a bridge of an NFT to some recipient's account on L1. Note that the current
+     *         owner of the token on this chain must approve this contract to operate the NFT before
+     *         it can be bridged.
      *
      * @param _localToken  Address of the ERC721 on this domain.
      * @param _remoteToken Address of the ERC721 on the remote domain.


### PR DESCRIPTION
Adds documentation for the ERC721 approval requirement in the NFT bridges.

N-10 affects multiple components, one of which is the NFT bridge.